### PR TITLE
Allow to use sorted maps as response bodies

### DIFF
--- a/src/macchiato/http.cljs
+++ b/src/macchiato/http.cljs
@@ -63,6 +63,11 @@
   (-write-response [data node-server-response _]
     (.write node-server-response (-> data clj->js js/JSON.stringify))
     (.end node-server-response))
+  
+  PersistentTreeMap
+  (-write-response [data node-server-response _]
+    (.write node-server-response (-> data clj->js js/JSON.stringify))
+    (.end node-server-response))
 
   PersistentVector
   (-write-response [data node-server-response raise]


### PR DESCRIPTION
I was trying to return a sorted JSON response by setting a `(sorted-map)` in the body and noticed that requires `PersistentTreeMap` implementing the `IHTTPResponseWriter` protocol to work.