### PR TITLE
fixed app crash when multiparty returns error

### DIFF
--- a/src/macchiato/middleware/multipart_params.cljs
+++ b/src/macchiato/middleware/multipart_params.cljs
@@ -50,17 +50,18 @@
       (.on form "progress" progress-fn))
     (.parse form (:body request)
             (fn [err fields files]
-              (let [params (merge
-                             (parse-file-params files)
-                             (parse-params fields))]
-                (if err
-                  (raise err)
+              (if err
+                (raise err)
+                (let [params (merge
+                               (parse-file-params files)
+                               (parse-params fields))]
                   (handler
                     (assoc request
                       :multipart-params params
                       :params params)
                     respond
-                    raise)))))))
+                    raise)))
+              ))))
 
 (defn
   ^{:macchiato/middleware


### PR DESCRIPTION
When multiparty returns error instead of fields and files (upload dir does not exist for example), 
app crashes with error
```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
```
So, just check for errors first, before `parse-file-params` and `parse-params`