### PR TITLE
fix not being able to set http-only cookie property false

### DIFF
--- a/src/macchiato/cookies.cljs
+++ b/src/macchiato/cookies.cljs
@@ -43,7 +43,7 @@
       (when path {:path path})
       (when domain {:domain domain})
       (when expires {:expires expires})
-      (when http-only {:http-only http-only})
+      (when (some? http-only) {:httpOnly http-only})
       (when overwrite? {:overwrite overwrite?}))))
 
 (defn- gen-keys [cookie-opts]


### PR DESCRIPTION
Pretty nasty bug, spent about 3 hours trying to figure out why I can't change my cookie properties from client side sometimes (at least I now understand http-only cookies better).