### PR TITLE
Add optional transit configuration

### DIFF
--- a/src/macchiato/util/response.cljs
+++ b/src/macchiato/util/response.cljs
@@ -94,13 +94,13 @@
 
 (defn transit
   "Turns the payload into a transit response."
-  [resp]
+  [resp & [{:keys [type opts]}]]
   (let [resp (if-not (response? resp)
                {:status 200
                 :headers {}
                 :body resp}
                resp)
-        write-transit #(t/write (t/writer :json) %)]
+        write-transit #(t/write (t/writer (or type :json) opts) %)]
     (-> resp
         (update-in [:body] write-transit)
         (content-type "application/transit+json"))))

--- a/test/macchiato/runner.cljs
+++ b/test/macchiato/runner.cljs
@@ -10,7 +10,7 @@
     [macchiato.test.middleware.not-modified]
     [macchiato.test.middleware.params]
     [macchiato.test.middleware.resource]
-    [macchiato.test.middleware.restul-format]
+    [macchiato.test.middleware.restful-format]
     [macchiato.test.middleware.session]
     [macchiato.test.middleware.ssl]
     [macchiato.test.middleware.x-headers]
@@ -27,7 +27,7 @@
            'macchiato.test.middleware.not-modified
            'macchiato.test.middleware.params
            'macchiato.test.middleware.resource
-           'macchiato.test.middleware.restul-format
+           'macchiato.test.middleware.restful-format
            'macchiato.test.middleware.session
            'macchiato.test.middleware.ssl
            'macchiato.test.util.mime-type

--- a/test/macchiato/test/middleware/restful_format.cljs
+++ b/test/macchiato/test/middleware/restful_format.cljs
@@ -85,36 +85,36 @@
         rf/default-accept-types))))
 
 (deftest test-roundtrip
-  (let [plain-request            (mock-node-request "hello" nil nil)
-        json-request             (mock-node-request
-                                   (json {:foo "bar"})
-                                   "application/json"
-                                   nil)
-        json-request-response    (mock-node-request
-                                   (json {:foo "bar"})
-                                   "application/json"
-                                   "application/json")
-        transit-request          (mock-node-request
-                                   (transit {:foo "bar"})
-                                   "application/transit+json"
-                                   nil)
-        transit-request-response (mock-node-request
-                                   (transit {:foo "bar"})
-                                   "application/transit+json"
-                                   "application/transit+json")
+  (let [plain-request                   (mock-node-request "hello" nil nil)
+        json-request                    (mock-node-request
+                                          (json {:foo "bar"})
+                                          "application/json"
+                                          nil)
+        json-request-response           (mock-node-request
+                                          (json {:foo "bar"})
+                                          "application/json"
+                                          "application/json")
+        transit-request                 (mock-node-request
+                                          (transit {:foo "bar"})
+                                          "application/transit+json"
+                                          nil)
+        transit-request-response        (mock-node-request
+                                          (transit {:foo "bar"})
+                                          "application/transit+json"
+                                          "application/transit+json")
         transit-custom-request-response (mock-node-request
                                           (transit {:point (MockPoint. 0 0)}
                                                    {:opts mock-write-handlers})
                                           "application/transit+json"
                                           "application/transit+json")
 
-        handler                  (rf/wrap-restful-format
-                                   (fn [req res raise]
-                                     (res (r/ok (:body req)))))
-        handler-keywordize       (rf/wrap-restful-format
-                                   (fn [req res raise]
-                                     (res (r/ok (:body req))))
-                                   {:keywordize? true})]
+        handler                         (rf/wrap-restful-format
+                                          (fn [req res raise]
+                                            (res (r/ok (:body req)))))
+        handler-keywordize              (rf/wrap-restful-format
+                                          (fn [req res raise]
+                                            (res (r/ok (:body req))))
+                                          {:keywordize? true})]
     (is (=
           (handler plain-request identity identity)
           {:status  200

--- a/test/macchiato/test/middleware/restful_format.cljs
+++ b/test/macchiato/test/middleware/restful_format.cljs
@@ -1,4 +1,4 @@
-(ns macchiato.test.middleware.restul-format
+(ns macchiato.test.middleware.restful-format
   (:require
     [cljs.test :refer-macros [is are deftest testing use-fixtures]]
     [cognitect.transit :as t]

--- a/test/macchiato/test/mock/transit.cljs
+++ b/test/macchiato/test/mock/transit.cljs
@@ -1,0 +1,17 @@
+(ns macchiato.test.mock.transit)
+
+(defrecord MockPoint [x y])
+
+(deftype MockPointWriteHandler []
+  Object
+  (tag [this v] "point")
+  (rep [this v] #js [(.-x v) (.-y v)])
+  (stringRep [this v] nil))
+
+(def mock-write-handlers
+  {:handlers
+   {MockPoint (MockPointWriteHandler.)}})
+
+(def mock-read-handlers
+  {:handlers
+   {"point" (fn [[x y]] (MockPoint. x y))}})


### PR DESCRIPTION
Wanted to get feedback before adding additional tests, renaming `restul_format.cljs -> restful_format.cljs`, aligning the formatting, etc.