### PR TITLE
Fix `Cannot read property '_handle' of null` error when using https

### DIFF
--- a/src/macchiato/http.cljs
+++ b/src/macchiato/http.cljs
@@ -33,7 +33,7 @@
      :protocol        (str (if (= :http scheme) "HTTP/" "HTTPS/") http-version)
      :secure?         (.-secure req)
      :signed-cookies  (js->clj (.-signedCookies req))
-     :ssl-client-cert (when-let [peer-cert-fn (.-getPeerCertificate conn)] (peer-cert-fn))
+     :ssl-client-cert (when (.-getPeerCertificate conn) (.getPeerCertificate conn))
      :stale?          (.-state req)
      :subdomains      (js->clj (.-subdomains req))
      :xhr?            (.-xhr req)


### PR DESCRIPTION
On macchiato-core 0.2.11 and clojurescript 1.10.339, when I provide a self-signed certificate to `macchiato.server/https-server` I'm getting the following error which prevents the server from handling requests:

```
TypeError: Cannot read property '_handle' of null
    at TLSSocket.getPeerCertificate (_tls_wrap.js:663:12)
    at /Users/zk/code/rx/target/dev/server/macchiato/http.js:23:21
    at macchiato$http$req__GT_map (/Users/zk/code/rx/target/dev/server/macchiato/http.js:27:3)
    at Server.macchiato.http.handler (/Users/zk/code/rx/target/dev/server/macchiato/http.js:346:58)
    at Server.emit (events.js:180:13)
    at parserOnIncoming (_http_server.js:642:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:117:17)
```

Tracked down to:

https://github.com/macchiato-framework/macchiato-core/blob/master/src/macchiato/http.cljs#L36 ->
https://github.com/nodejs/node/blob/master/lib/_tls_wrap.js#L666

and it looks like `this` is getting clobbered by storing `getPeerCertificate` in the `when-let` and calling.

I couldn't find an appropriate test location for this. Happy to add one, although I believe that would require adding a bunch of machinery around creating a 'real' node request object and running it through the system, so understand if that's not something you all are comfortable with.