### PR TITLE
Fix error handler being called incorrectly when exception during response processing

### DIFF
--- a/src/macchiato/http.cljs
+++ b/src/macchiato/http.cljs
@@ -114,9 +114,10 @@
 (defn handler [http-handler opts]
   (let [opts (-> opts (update-in [:cookies :signed?] (fnil identity true)))]
     (fn [node-client-request node-server-response]
-      (http-handler (req->map node-client-request node-server-response opts)
-                    (response node-client-request node-server-response error-handler opts)
-                    (error-handler node-server-response)))))
+      (let [handle-error (error-handler node-server-response)]
+        (http-handler (req->map node-client-request node-server-response opts)
+                      (response node-client-request node-server-response handle-error opts)
+                      handle-error)))))
 
 (defn ws-handler [handler opts]
   (let [opts (-> opts (update-in [:cookies :signed?] (fnil identity true)))]

--- a/src/macchiato/http.cljs
+++ b/src/macchiato/http.cljs
@@ -108,7 +108,7 @@
   (fn [error]
     (doto node-server-response
       (.writeHead 500 #js {"content-type" "text/html"})
-      (.write (.-message error))
+      (.write (str error))
       (.end))))
 
 (defn handler [http-handler opts]


### PR DESCRIPTION
In macchiato-core 0.2.13, an exception encountered during request processing will prevent the node server from responding, causing the client to time out.

The cause can be seen here:

https://github.com/macchiato-framework/macchiato-core/blob/e5ec039ad0c028736c5ecfa21c439bb217813248/src/macchiato/http.cljs#L118

The third parameter to `response` should be the result of calling `error-handler`, not the function itself.

I've also changed the behavior of error handler to return the `toString` of the entire error instead of just the message (second commit in this PR), but feel free to roll that back if you feel that's not appropriate.



