### PR TITLE
Fixed buffer constructor deprecation warning

### DIFF
--- a/src/macchiato/middleware/session/cookie.cljs
+++ b/src/macchiato/middleware/session/cookie.cljs
@@ -8,13 +8,13 @@
   "Seal a Clojure data structure into an encrypted and HMACed string."
   [key data]
   (let [data (c/encrypt key (pr-str data))]
-    (str (.toString (js/Buffer. data) "base64") "--" (c/hmac key data))))
+    (str (.toString (.from js/Buffer data) "base64") "--" (c/hmac key data))))
 
 (defn- unseal
   "Retrieve a sealed Clojure data structure from a string"
   [key string]
   (let [[data mac] (.split string "--")
-        data (.toString (js/Buffer. data "base64") "utf8")]
+        data (.toString (.from js/Buffer data "base64") "utf8")]
     (if (c/eq? mac (c/hmac key data))
       (edn/read-string (c/decrypt key data)))))
 

--- a/test/macchiato/test/middleware/resource.cljs
+++ b/test/macchiato/test/middleware/resource.cljs
@@ -7,7 +7,7 @@
 
 (def target (path/resolve "test"))
 
-(def target-file (str target "/runner.cljs"))
+(def target-file (str target path/separator "runner.cljs"))
 
 (deftest test-resource-path
   (testing "absolute path"


### PR DESCRIPTION
The resource tests were failing when running on Windows due to the file separator being different.