### PR TITLE
Add IPC (UNIX/Windows domain socket) listener support

### DIFF
--- a/src/macchiato/server.cljs
+++ b/src/macchiato/server.cljs
@@ -32,6 +32,16 @@
     (.listen server port host on-success)
     server))
 
+(defn ipc-server
+  ":ipc-path - UNIX/Windows domain socket the server will listen on
+  :handler - Macchiato handler function for handling request/response
+  :on-success - success callback that's called when server starts listening"
+  [{:keys [handler ipc-path on-success websockets?] :as opts}]
+  (let [http-handler (http/handler handler (assoc opts :scheme :http))
+        server       (.createServer (node/require "http") http-handler)]
+    (.listen server ipc-path on-success)
+    server))
+
 (defn start
   ":host - hostname to bind (default 0.0.0.0)
   :port - HTTP port the server will listen on
@@ -48,7 +58,8 @@
   (case protocol
     :http (http-server opts)
     :https (https-server opts)
-    (throw (js/Error. (str "Unrecognized protocol: " protocol " must be either :http or :https")))))
+    :ipc (ipc-server opts)
+    (throw (js/Error. (str "Unrecognized protocol: " protocol " must be :http, :https, or :ipc")))))
 
 (defn start-ws
   "starts a WebSocket server given a handler and a Node server instance"


### PR DESCRIPTION
This change makes it possible to host Macchiato-based services on IPC (aka "UNIX domain") sockets. You can then use something like Nginx to do SSL termination, auth, etc. before proxying requests to the Node.js process. That already works today with TCP-based HTTP sockets, but that approaches exposes the TCP port on the local machine, whereas UNIX sockets can be controlled with filesystem ACLs.

I tested this change on Linux with an Nginx frontend and confirmed that WebSockets work as well. Existing HTTP(S) functionality is unchanged.

Lastly, I chose to set the handler scheme to `:http` when using the `:ipc` protocol (as opposed to allowing that as an additional option) since my assumption is that the IPC listener will only ever be used when there is a front-end host that is managing the actual HTTP(S) connection.