### PR TITLE
[FIX] (server): add some type hints when creating the server (Fixes #44)

### DIFF
--- a/src/macchiato/http.cljs
+++ b/src/macchiato/http.cljs
@@ -9,7 +9,7 @@
 
 (def ^:no-doc url-parser (node/require "url"))
 
-(defn- req->map [req res {:keys [scheme] :as opts}]
+(defn- req->map [^js req ^js res {:keys [scheme] :as opts}]
   (let [conn         (.-connection req)
         url          (.parse url-parser (.-url req))
         http-version (.-httpVersion req)
@@ -91,12 +91,12 @@
     (.end node-server-response))
 
   Stream
-  (-write-response [data node-server-response raise]
+  (-write-response [data ^js node-server-response raise]
     (.on data "error" (fn [err]
                         (.destroy (.-socket node-server-response) err)))
     (.pipe data node-server-response)))
 
-(defn- response [request-map node-server-response raise opts]
+(defn- response [request-map ^js node-server-response raise opts]
   (fn [{:keys [cookies headers body status]}]
     (try
       (cookies/set-cookies cookies request-map node-server-response (:cookies opts))
@@ -105,7 +105,7 @@
       (catch js/Error e
         (raise e)))))
 
-(defn- error-handler [node-server-response]
+(defn- error-handler [^js node-server-response]
   (fn [error]
     (doto node-server-response
       (.writeHead 500 #js {"content-type" "text/html"})

--- a/src/macchiato/server.cljs
+++ b/src/macchiato/server.cljs
@@ -13,7 +13,8 @@
   :on-success - success callback that's called when server starts listening"
   [{:keys [handler host port on-success websockets?] :as opts}]
   (let [http-handler (http/handler handler (assoc opts :scheme :http))
-        server       (.createServer (node/require "http") http-handler)]
+        ^js module (node/require "http")
+        ^js server (.createServer module http-handler)]
     (.listen server port host on-success)
     server))
 
@@ -28,7 +29,8 @@
   (let [pk           (fs/slurp private-key)
         pc           (fs/slurp certificate)
         http-handler (http/handler handler (assoc opts :scheme :https))
-        server       (.createServer (node/require "https") (clj->js {:key pk :cert pc}) http-handler)]
+        ^js module   (node/require "https")
+        ^js server   (.createServer module (clj->js {:key pk :cert pc}) http-handler)]
     (.listen server port host on-success)
     server))
 
@@ -38,7 +40,8 @@
   :on-success - success callback that's called when server starts listening"
   [{:keys [handler ipc-path on-success websockets?] :as opts}]
   (let [http-handler (http/handler handler (assoc opts :scheme :http))
-        server       (.createServer (node/require "http") http-handler)]
+        ^js module   (node/require "http")
+        ^js server   (.createServer module http-handler)]
     (.listen server ipc-path on-success)
     server))
 
@@ -64,5 +67,5 @@
 (defn start-ws
   "starts a WebSocket server given a handler and a Node server instance"
   [server handler & [opts]]
-  (let [wss (ws.Server. #js{:server server})]
+  (let [^js wss (ws.Server. #js{:server server})]
     (.on wss "connection" (http/ws-handler handler opts))))


### PR DESCRIPTION
[FIX] (server): add some type hints when creating the server to avoid breakages when compiling in release mode