### PR TITLE
avoid node/require & replace with ns-form instead

### DIFF
--- a/src/macchiato/cookies.cljs
+++ b/src/macchiato/cookies.cljs
@@ -1,10 +1,7 @@
 (ns macchiato.cookies
   (:require
-    [cljs.nodejs :as node]))
-
-(def ^:no-doc Cookies (node/require "cookies"))
-
-(def ^:no-doc random-bytes (node/require "random-bytes"))
+    ["cookies" :as Cookies]
+    ["random-bytes" :as random-bytes]))
 
 (def ^:no-doc secret (str (random-bytes. 32)))
 

--- a/src/macchiato/crypto.cljs
+++ b/src/macchiato/crypto.cljs
@@ -1,9 +1,7 @@
 (ns macchiato.crypto
   (:require
-    [cljs.nodejs :as node]))
-
-(def ^:no-doc crypto (node/require "crypto"))
-(def ^:no-doc encryptor (node/require "simple-encryptor"))
+    ["crypto" :as crypto]
+    ["simple-encryptor" :as encryptor]))
 
 (defn encrypt [key data]
   (.encrypt (encryptor. key) data))

--- a/src/macchiato/http.cljs
+++ b/src/macchiato/http.cljs
@@ -3,11 +3,8 @@
     [cuerdas.core :as s]
     [macchiato.cookies :as cookies]
     [macchiato.middleware.session :as session]
-    [cljs.nodejs :as node]))
-
-(def ^:no-doc Stream (node/require "stream"))
-
-(def ^:no-doc url-parser (node/require "url"))
+    ["stream" :as Stream]
+    ["url" :as url-parser]))
 
 (defn- req->map [^js req ^js res {:keys [scheme] :as opts}]
   (let [conn         (.-connection req)

--- a/src/macchiato/middleware/file.cljs
+++ b/src/macchiato/middleware/file.cljs
@@ -1,13 +1,11 @@
 (ns macchiato.middleware.file
   (:require
-    [cljs.nodejs :as node]
     [cljs-time.core :refer [before?]]
     [macchiato.fs :as fs]
     [macchiato.util.response :as res]
-    [macchiato.util.mime-type :refer [ext-mime-type]]))
-
-(def Stream (node/require "stream"))
-(def etag (node/require "etag"))
+    [macchiato.util.mime-type :refer [ext-mime-type]]
+    ["stream" :as Stream]
+    ["etag" :as etag]))
 
 (defn- guess-mime-type
   "Returns a String corresponding to the guessed mime type for the given file,

--- a/src/macchiato/middleware/multipart_params.cljs
+++ b/src/macchiato/middleware/multipart_params.cljs
@@ -1,11 +1,10 @@
 (ns macchiato.middleware.multipart-params
   (:require
-    [cljs.nodejs :as node]
     [macchiato.middleware.nested-params :as np]
-    [macchiato.util.request :as req]))
+    [macchiato.util.request :as req]
+    ;; https://www.npmjs.com/package/multiparty
+    ["multiparty" :as multiparty]))
 
-;; https://www.npmjs.com/package/multiparty
-(def multiparty (node/require "multiparty"))
 
 (defn- multipart-form?
   "Does a request have a multipart form?"
@@ -45,7 +44,7 @@
     {} (js/Object.keys files)))
 
 (defn- multipart-request [handler request respond raise {:keys [progress-fn] :as opts}]
-  (let [form (multiparty.Form. (parse-opts opts))]
+  (let [form (multiparty/Form. (parse-opts opts))]
     (when progress-fn
       (.on form "progress" progress-fn))
     (.parse form (:body request)

--- a/src/macchiato/middleware/not_modified.cljs
+++ b/src/macchiato/middleware/not_modified.cljs
@@ -1,12 +1,11 @@
 (ns macchiato.middleware.not-modified
   "Middleware that returns a 304 Not Modified response for responses with Last-Modified headers."
   (:require
-    [cljs.nodejs :as node]
     [cljs-time.core :refer [before?]]
     [macchiato.util.time :refer [parse-date]]
-    [macchiato.util.response :refer [status get-header header]]))
+    [macchiato.util.response :refer [status get-header header]]
+    ["stream" :as Stream]))
 
-(def Stream (node/require "stream"))
 
 (defn- etag-match? [request response]
   (if-let [etag (get-header response "ETag")]

--- a/src/macchiato/middleware/params.cljs
+++ b/src/macchiato/middleware/params.cljs
@@ -1,11 +1,8 @@
 (ns macchiato.middleware.params
   (:require
-    [cljs.nodejs :as node]
-    [macchiato.util.request :as req]))
-
-(def qs (node/require "qs"))
-
-(def concat-stream (node/require "concat-stream"))
+    [macchiato.util.request :as req]
+    ["qs" :as qs]
+    ["concat-stream" :as concat-stream]))
 
 (defn decode [s]
   (js->clj (.parse qs s)))

--- a/src/macchiato/middleware/restful_format.cljs
+++ b/src/macchiato/middleware/restful_format.cljs
@@ -1,16 +1,14 @@
 (ns macchiato.middleware.restful-format
   (:require
-    [cljs.nodejs :as node]
     [cognitect.transit :as t]
     [cljs.reader :as edn]
     [macchiato.util.request :as rq]
-    [macchiato.util.response :as r]))
+    [macchiato.util.response :as r]
+    ["concat-stream" :as concat-stream]
+    ["content-type" :as ct]
+    ["lru" :as node-lru]))
 
-(def concat-stream (node/require "concat-stream"))
-
-(def ct (node/require "content-type"))
-
-(def lru (let [LRUCache (node/require "lru")]
+(def lru (let [LRUCache node-lru]
            (LRUCache. #js {:maxElementsToStore 500})))
 
 (defn parse-accept-header [accept-header]

--- a/src/macchiato/middleware/ssl.cljs
+++ b/src/macchiato/middleware/ssl.cljs
@@ -1,11 +1,9 @@
 (ns macchiato.middleware.ssl
   "Middleware for managing handlers operating over HTTPS."
-  (:require [cljs.nodejs :as node]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [macchiato.util.response :as resp]
-            [macchiato.util.request :as req]))
-
-(def url (node/require "url"))
+            [macchiato.util.request :as req]
+            ["url" :as url]))
 
 (def default-scheme-header
   "The default header used in wrap-forwarded-scheme (x-forwarded-proto)."

--- a/src/macchiato/server.cljs
+++ b/src/macchiato/server.cljs
@@ -1,10 +1,10 @@
 (ns macchiato.server
   (:require
-    [cljs.nodejs :as node]
     [macchiato.fs :as fs]
-    [macchiato.http :as http]))
-
-(def ^:no-doc ws (node/require "ws"))
+    [macchiato.http :as http]
+    ["ws" :as ws]
+    ["http" :as node-http]
+    ["https" :as node-https]))
 
 (defn http-server
   ":host - hostname to bind
@@ -13,7 +13,7 @@
   :on-success - success callback that's called when server starts listening"
   [{:keys [handler host port on-success websockets?] :as opts}]
   (let [http-handler (http/handler handler (assoc opts :scheme :http))
-        ^js module (node/require "http")
+        ^js module node-http
         ^js server (.createServer module http-handler)]
     (.listen server port host on-success)
     server))
@@ -29,7 +29,7 @@
   (let [pk           (fs/slurp private-key)
         pc           (fs/slurp certificate)
         http-handler (http/handler handler (assoc opts :scheme :https))
-        ^js module   (node/require "https")
+        ^js module   node-https
         ^js server   (.createServer module (clj->js {:key pk :cert pc}) http-handler)]
     (.listen server port host on-success)
     server))
@@ -40,7 +40,7 @@
   :on-success - success callback that's called when server starts listening"
   [{:keys [handler ipc-path on-success websockets?] :as opts}]
   (let [http-handler (http/handler handler (assoc opts :scheme :http))
-        ^js module   (node/require "http")
+        ^js module   node-http
         ^js server   (.createServer module http-handler)]
     (.listen server ipc-path on-success)
     server))
@@ -67,5 +67,5 @@
 (defn start-ws
   "starts a WebSocket server given a handler and a Node server instance"
   [server handler & [opts]]
-  (let [^js wss (ws.Server. #js{:server server})]
+  (let [^js wss (ws/Server. #js{:server server})]
     (.on wss "connection" (http/ws-handler handler opts))))

--- a/test/macchiato/test/middleware/params.cljs
+++ b/test/macchiato/test/middleware/params.cljs
@@ -1,10 +1,10 @@
 (ns macchiato.test.middleware.params
   (:require
-    [cljs.nodejs :as node]
     [macchiato.middleware.params :refer [wrap-params]]
     [macchiato.test.mock.request :refer [header request]]
     [macchiato.test.mock.util :refer [mock-handler raw-response ok-response]]
-    [cljs.test :refer-macros [is are deftest testing use-fixtures]]))
+    [cljs.test :refer-macros [is are deftest testing use-fixtures]]
+    ["stream" :as Stream]))
 
 (defn wrapped-echo [req]
   ((mock-handler wrap-params (fn [req res rais] (res req)))
@@ -17,7 +17,7 @@
     (is (empty? (:form-params resp)))
     (is (= {"foo" "bar" "biz" "bat%"} (:params resp)))))
 
-(def readable (.-Readable (node/require "stream")))
+(def readable (.-Readable Stream))
 
 (defn str->stream [s]
   (doto (doto (readable.))

--- a/test/macchiato/test/middleware/restful_format.cljs
+++ b/test/macchiato/test/middleware/restful_format.cljs
@@ -7,8 +7,7 @@
     [macchiato.util.response :as r]
     [macchiato.test.mock.request :refer [request]]
     [macchiato.test.mock.util :refer [mock-handler raw-response ok-response]]
-    [macchiato.test.mock.transit :refer [MockPoint mock-write-handlers mock-read-handlers]]
-    [cljs.nodejs :as node]))
+    [macchiato.test.mock.transit :refer [MockPoint mock-write-handlers mock-read-handlers]]))
 
 (defn- mock-node-request [body content-type accept-type]
   (-> (request :post "/")

--- a/test/macchiato/test/mock/request.cljs
+++ b/test/macchiato/test/mock/request.cljs
@@ -1,10 +1,8 @@
 (ns macchiato.test.mock.request
   (:require
-    [cljs.nodejs :as node]
-    [clojure.string :as s]))
-
-(def url (node/require "url"))
-(def querystring (node/require "querystring"))
+    [clojure.string :as s]
+    ["url" :as url]
+    ["querystring" :as querystring]))
 
 (defn- encode-params
   "Turn a map of parameters into a urlencoded string."


### PR DESCRIPTION
This commit replaces explicit `node/require` calls with the ns-form of these requires instead. That way, shadow-cljs, for example, can bundle things into a standalone node-script. Right now it can't, because it can't detect/infer these dependencies.